### PR TITLE
fix(text-icon-panel): 修正文字上限從 3 字元改為 2 字元

### DIFF
--- a/features/icon-picker/components/TextIconPanel.vue
+++ b/features/icon-picker/components/TextIconPanel.vue
@@ -6,8 +6,8 @@
       <input
         v-model="customInitials"
         type="text"
-        maxlength="3"
-        placeholder="最多3個字元 (如: AB)"
+        maxlength="2"
+        placeholder="最多2個字元 (如: AB)"
         class="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
         @input="handleInitialsInput"
       />
@@ -62,10 +62,10 @@ export default {
       }
     }, { immediate: true })
     
-    // 處理文字輸入 - 限制3字元並自動大寫
+    // 處理文字輸入 - 限制2字元並自動大寫
     const handleInitialsInput = () => {
       if (customInitials.value) {
-        customInitials.value = customInitials.value.toUpperCase().slice(0, 3)
+        customInitials.value = customInitials.value.toUpperCase().slice(0, 2)
       }
       // 即時更新 modelValue
       emit('update:modelValue', customInitials.value)

--- a/features/icon-picker/tests/components/TextIconPanel.test.js
+++ b/features/icon-picker/tests/components/TextIconPanel.test.js
@@ -12,16 +12,16 @@ describe('TextIconPanel', () => {
     expect(wrapper.find('.w-24.h-24').exists()).toBe(true) // 預覽區域
   })
 
-  it('應該限制輸入為3個字元', async () => {
+  it('應該限制輸入為2個字元', async () => {
     const wrapper = mount(TextIconPanel)
     const input = wrapper.find('input')
     
-    // 輸入超過3個字元
+    // 輸入超過2個字元
     await input.setValue('ABCDE')
     await input.trigger('input')
     
-    // 應該只保留前3個字元
-    expect(wrapper.vm.customInitials).toBe('ABC')
+    // 應該只保留前2個字元
+    expect(wrapper.vm.customInitials).toBe('AB')
   })
 
   it('應該自動轉換為大寫', async () => {
@@ -29,11 +29,11 @@ describe('TextIconPanel', () => {
     const input = wrapper.find('input')
     
     // 輸入小寫字母
-    await input.setValue('abc')
+    await input.setValue('ab')
     await input.trigger('input')
     
     // 應該轉換為大寫
-    expect(wrapper.vm.customInitials).toBe('ABC')
+    expect(wrapper.vm.customInitials).toBe('AB')
   })
 
   it('應該在有輸入時啟用應用按鈕', async () => {


### PR DESCRIPTION
## 修正內容

此 PR 實作 **ST-FIX-001: 修正 TextIconPanel 文字上限為 2 字元**

### 📝 變更摘要

- ✅ 修正 `TextIconPanel.vue` 中 `maxlength` 從 3 改為 2
- ✅ 修正 placeholder 文字描述為"最多2個字元 (如: AB)"
- ✅ 修正 JavaScript 邏輯中的 `slice(0, 3)` 改為 `slice(0, 2)`  
- ✅ 更新相關測試期望值以符合新的 2 字元限制
- ✅ 所有測試通過驗證

### 🔧 修正檔案

1. **features/icon-picker/components/TextIconPanel.vue**
   - Line 9: `maxlength="3"` → `maxlength="2"`
   - Line 10: `"最多3個字元"` → `"最多2個字元"`
   - Line 68: `slice(0, 3)` → `slice(0, 2)`

2. **features/icon-picker/tests/components/TextIconPanel.test.js**
   - 更新測試描述和期望值
   - 確保測試符合新的 2 字元限制

### ✅ 驗收條件完成

- [x] TextIconPanel.vue 修正 maxlength 為 2
- [x] 更新 placeholder 文字為 "最多2個字元 (如: AB)"
- [x] 檢查其他相關檔案的一致性修正
- [x] 更新相關測試的期望值
- [x] 驗證功能在測試頁面正常運作

### 🧪 測試結果

```bash
✓ features/icon-picker/tests/components/TextIconPanel.test.js (13 tests) 200ms
Test Files  1 passed (1)
Tests  13 passed (13)
```

### 🎯 功能驗證

- ✅ 文字輸入限制為 2 字元
- ✅ 輸入超過 2 字元時自動截斷
- ✅ 大寫轉換功能正常
- ✅ 預覽顯示正確
- ✅ 顏色計算邏輯不受影響
- ✅ 應用按鈕狀態管理正確

### 📋 相關 Story

- **ST-FIX-001**: 修正 TextIconPanel 文字上限為 2 字元 ✅ 已完成

### 🔗 相關 PR

此修正為 IconPicker 重構計劃的一部分，後續將繼續實作其他面板元件。

🤖 Generated with [Claude Code](https://claude.ai/code)