### PR TITLE
fix(emoji-panel): 修正膚色套用功能測試

### DIFF
--- a/resources/js/features/icon-picker/tests/components/EmojiPanel.test.js
+++ b/resources/js/features/icon-picker/tests/components/EmojiPanel.test.js
@@ -454,10 +454,44 @@ describe('EmojiPanel', () => {
     })
 
     it('應該只對支援膚色的 emoji 套用膚色修飾符', async () => {
+      // 使用包含膚色資訊的 mock 資料
+      const mockDataWithSkinTone = [
+        {
+          categoryId: 'people',
+          categoryName: '人物',
+          emojis: [
+            {
+              emoji: '👋',
+              name: 'waving hand',
+              category: 'people',
+              has_skin_tone: true,
+              skin_variations: {
+                1: '👋🏻',
+                2: '👋🏼',
+                3: '👋🏽',
+                4: '👋🏾',
+                5: '👋🏿'
+              }
+            },
+            {
+              emoji: '😀',
+              name: 'grinning face',
+              category: 'people',
+              has_skin_tone: false
+            }
+          ]
+        }
+      ]
+
+      // Mock IconDataLoader 返回包含膚色資料的結構
+      vi.mocked(IconDataLoader).mockImplementation(() => ({
+        getEmojiData: vi.fn().mockResolvedValue(mockDataWithSkinTone)
+      }))
+
       wrapper = mount(EmojiPanel, {
         props: {
           searchQuery: '',
-          selectedSkinTone: '🏻'
+          selectedSkinTone: '1'  // 使用數字而非 emoji 字符
         }
       })
 


### PR DESCRIPTION
## Summary
修正 EmojiPanel 中失敗的膚色套用功能測試，解決 mock 資料結構和參數格式問題。

## 問題描述
- EmojiPanel 測試中「應該只對支援膚色的 emoji 套用膚色修飾符」失敗
- 測試使用的 mock 資料缺少必要的膚色支援屬性
- selectedSkinTone 參數格式不正確（使用 emoji 字符而非數字）

## 解決方案  
- ✅ 更新測試 mock 資料，加入 `has_skin_tone` 和 `skin_variations` 屬性
- ✅ 修正 `selectedSkinTone` 從 `'🏻'` 改為 `'1'` (數字格式)
- ✅ 確保測試使用包含膚色支援資訊的完整資料結構

## 測試結果
```
✓ EmojiPanel (26/26 tests passed)
- 所有測試現已通過，包括修正的膚色套用測試
- 測試涵蓋完整的膚色功能：套用、過濾、結構化支援
```

## TDD 開發流程
- 🔴 **RED**: 分析失敗測試，確定問題根因
- 🟢 **GREEN**: 修正測試 mock 資料和參數格式  
- 🔵 **REFACTOR**: 驗證修正精簡有效，無需進一步重構

## 驗收條件檢查
- [x] 所有 EmojiPanel 測試通過 (26/26)
- [x] 膚色套用邏輯正確運作
- [x] 測試使用正確的資料結構
- [x] 無 breaking changes

## 相關 Story
- ST-013: 實作 EmojiPanel（含完整解決方案）

🤖 Generated with [Claude Code](https://claude.ai/code)