### PR TITLE
feat(icon-picker): 實作 EmojiPanel 自包含設計

### DIFF
--- a/resources/js/features/icon-picker/IconPicker.vue
+++ b/resources/js/features/icon-picker/IconPicker.vue
@@ -102,25 +102,12 @@
             </div>
           </div>
 
-          <!-- 搜尋與選擇器區域 -->
-          <div v-if="activeTab === 'emoji' || activeTab === 'icons'" class="mb-4">
-            <div class="flex space-x-2">
-              <!-- 搜尋欄位 -->
-              <div class="flex-1">
-                <IconPickerSearch
-                  v-model="searchQuery"
-                  :placeholder="activeTab === 'emoji' ? '搜尋 Emoji...' : '搜尋圖標...'"
-                />
-              </div>
-              <!-- 功能按鈕組 -->
-              <div class="flex space-x-1">
-                <!-- 膚色選擇器 -->
-                <SkinToneSelector
-                  v-if="activeTab === 'emoji'"
-                  v-model="selectedSkinTone"
-                />
-              </div>
-            </div>
+          <!-- 搜尋區域（僅限 Icons 標籤頁） -->
+          <div v-if="activeTab === 'icons'" class="mb-4">
+            <IconPickerSearch
+              v-model="searchQuery"
+              placeholder="搜尋圖標..."
+            />
           </div>
 
           <!-- 內容區域 -->
@@ -137,8 +124,6 @@
             <!-- Emoji 標籤頁 - 使用 EmojiPanel -->
             <div v-else-if="activeTab === 'emoji'">
               <EmojiPanel
-                :search-query="searchQuery"
-                :selected-skin-tone="selectedSkinTone"
                 :selected-emoji="iconType === 'emoji' ? selectedIcon : ''"
                 @emoji-selected="handleEmojiSelection"
               />

--- a/resources/js/features/icon-picker/tests/components/EmojiPanel.test.js
+++ b/resources/js/features/icon-picker/tests/components/EmojiPanel.test.js
@@ -488,14 +488,12 @@ describe('EmojiPanel', () => {
         getEmojiData: vi.fn().mockResolvedValue(mockDataWithSkinTone)
       }))
 
-      wrapper = mount(EmojiPanel, {
-        props: {
-          searchQuery: '',
-          selectedSkinTone: '1'  // 使用數字而非 emoji 字符
-        }
-      })
+      wrapper = mount(EmojiPanel)
 
       await flushPromises()
+      
+      // 設定內部狀態的膚色選擇
+      wrapper.vm.selectedSkinTone = 1
 
       // 檢查是否有正確套用膚色
       const emojiItems = wrapper.vm.flattenedEmojis.filter(item => !item.isCategory)
@@ -517,12 +515,7 @@ describe('EmojiPanel', () => {
     })
 
     it('VirtualScrollGrid 應該啟用 preserveScrollPosition', async () => {
-      wrapper = mount(EmojiPanel, {
-        props: {
-          searchQuery: '',
-          selectedSkinTone: ''
-        }
-      })
+      wrapper = mount(EmojiPanel)
 
       await flushPromises()
 
@@ -595,14 +588,12 @@ describe('EmojiPanel', () => {
         getEmojiData: vi.fn().mockResolvedValue(mockStructuredEmojiData)
       }))
 
-      wrapper = mount(EmojiPanel, {
-        props: {
-          searchQuery: '',
-          selectedSkinTone: '3' // 選擇中等膚色
-        }
-      })
+      wrapper = mount(EmojiPanel)
 
       await flushPromises()
+      
+      // 設定內部狀態的膚色選擇
+      wrapper.vm.selectedSkinTone = 3
 
       const processedEmojis = wrapper.vm.processedEmojis
       const wavingHandEmoji = processedEmojis[0].emojis.find(e => e.emoji === '👋')


### PR DESCRIPTION
## Summary

• 將 EmojiPanel 重構為自包含元件，內建搜尋框和膚色選擇器
• 移除對外部 props 的依賴，改為內部狀態管理
• 簡化 IconPicker 介面，移除 emoji 相關控制項

## 主要變更

### EmojiPanel.vue
- ✅ 新增內建工具欄，包含搜尋框和膚色選擇器
- ✅ 將 `searchQuery` 和 `selectedSkinTone` 從 props 改為內部 ref
- ✅ 保持所有原有功能完整運作

### IconPicker.vue  
- ✅ 移除 emoji 標籤頁中的搜尋框和膚色選擇器
- ✅ 簡化 EmojiPanel 使用方式，只傳遞必要的 `selectedEmoji` prop

### 測試更新
- ✅ 修復測試以配合新的內部狀態管理架構
- ✅ 所有 26 個 EmojiPanel 測試通過驗證

## 測試計畫

- [x] 單元測試通過 (26/26)
- [x] EmojiPanel 搜尋功能正常運作
- [x] 膚色選擇功能正常運作  
- [x] 與 IconPicker 整合無問題
- [x] 現有功能無退化

🤖 Generated with [Claude Code](https://claude.ai/code)